### PR TITLE
Websocket connectivity fixes

### DIFF
--- a/src/context/useRpcProvider.js
+++ b/src/context/useRpcProvider.js
@@ -1,6 +1,12 @@
 import {ethers} from 'ethers';
 import React, {useContext, createContext, useState} from 'react';
 
+function keepAlive(provider) {
+	provider.keepAliveInterval = setInterval(async () => {
+		await provider.send('eth_blockNumber');
+	}, 55_000);
+}
+
 const RPCProvider = createContext();
 export const RPCProviderContextApp = ({children}) => {
 	const [defaultProvider, setDefaultProvider] = useState();
@@ -37,8 +43,9 @@ export const RPCProviderContextApp = ({children}) => {
 			promises.push(promise);
 		}
 		let def = await Promise.race(promises);
-		setDefaultProvider(def);
 		eth_nodes.filter(n => n !== def).forEach(n => n.destroy());
+		setDefaultProvider(def);
+		keepAlive(def);
 
 		promises = [];
 		for(let provider of ftm_nodes){
@@ -50,6 +57,7 @@ export const RPCProviderContextApp = ({children}) => {
 		let fan = await Promise.race(promises);
 		ftm_nodes.filter(n => n !== fan).forEach(n => n.destroy());
 		setFantomProvider(fan);
+		keepAlive(fan);
 
 		return [def, fan];
 	}

--- a/src/context/useRpcProvider.js
+++ b/src/context/useRpcProvider.js
@@ -3,51 +3,32 @@ import React, {useContext, createContext, useState} from 'react';
 
 const RPCProvider = createContext();
 export const RPCProviderContextApp = ({children}) => {
-	const [defaultProvider, setDefaultProvider] = useState(new ethers.providers.WebSocketProvider(
-		process.env.REACT_APP_ETH_WS_PROVIDER, {
-			name: 'ethereum',
-			chainId: 1
-		}
-	));
-	const [fantomProvider, setFantomProvider] = useState(new ethers.providers.WebSocketProvider(
-		process.env.REACT_APP_FTM_WS_PROVIDER3, {
-			name: 'fantom',
-			chainId: 250
-		}
-	));
-
-
-	const def_network = {
-		name: 'ethereum',
-		chainId: 1
-	};
-	const eth_nodes = [];
-	
-	eth_nodes.push(new ethers.providers.WebSocketProvider(
-		process.env.REACT_APP_ETH_WS_PROVIDER, def_network
-	));
-	if(process.env.REACT_APP_ETH_WS_PROVIDER_BACKUP){
-
-		const n = new ethers.providers.WebSocketProvider(
-			process.env.REACT_APP_ETH_WS_PROVIDER_BACKUP, def_network
-		);
-		eth_nodes.push(n);
-	}
-
-	const network = {
-		name: 'fantom',
-		chainId: 250
-	};
-
-	const ftm_nodes = [];
-	
-	ftm_nodes.push(new ethers.providers.WebSocketProvider(
-		process.env.REACT_APP_FTM_WS_PROVIDER3, network
-	));
-	
+	const [defaultProvider, setDefaultProvider] = useState();
+	const [fantomProvider, setFantomProvider] = useState();	
 	const [tenderlyProvider, setTenderly] = useState(null);
 
 	async function initProviders() {
+		const eth_nodes = [];
+		eth_nodes.push(new ethers.providers.WebSocketProvider(
+			process.env.REACT_APP_ETH_WS_PROVIDER, {
+				name: 'ethereum',
+				chainId: 1
+			}));
+		if(process.env.REACT_APP_ETH_WS_PROVIDER_BACKUP){
+			eth_nodes.push(new ethers.providers.WebSocketProvider(
+				process.env.REACT_APP_ETH_WS_PROVIDER_BACKUP, {
+					name: 'ethereum',
+					chainId: 1
+				}));
+		}
+
+		const ftm_nodes = [];
+		ftm_nodes.push(new ethers.providers.WebSocketProvider(
+			process.env.REACT_APP_FTM_WS_PROVIDER3, {
+				name: 'fantom',
+				chainId: 250
+			}));
+
 		let promises = [];
 		for(let provider of eth_nodes){
 			let promise = new Promise(function(resolve){
@@ -57,8 +38,7 @@ export const RPCProviderContextApp = ({children}) => {
 		}
 		let def = await Promise.race(promises);
 		setDefaultProvider(def);
-		console.log(defaultProvider);
-		
+		eth_nodes.filter(n => n !== def).forEach(n => n.destroy());
 
 		promises = [];
 		for(let provider of ftm_nodes){
@@ -68,6 +48,7 @@ export const RPCProviderContextApp = ({children}) => {
 			promises.push(promise);
 		}
 		let fan = await Promise.race(promises);
+		ftm_nodes.filter(n => n !== fan).forEach(n => n.destroy());
 		setFantomProvider(fan);
 
 		return [def, fan];
@@ -97,7 +78,6 @@ export const RPCProviderContextApp = ({children}) => {
 				console.log(tenderlyProvider);
 			});
 	}
-
 
 	return (
 		<RPCProvider.Provider


### PR DESCRIPTION

### Intermittently the app can't establish new wss connections
We've noticed this while developing. Reviewing the app's network connections showed a lot of extra\unused websockets being opened. This PR cleans those up, the idea being that maybe the rpc servers are limiting socket count per client. (It's also just good to cleanup the extra sockets of course!)

### If the app isn't used for 60 seconds, established websockets "timeout" and close
The problem here seems to be the rpc servers terminating sockets after one minute of no activity.  We're using ethersjs for our rpc client which doesn't currently have logic to auto-reconnect closed sockets (https://github.com/ethers-io/ethers.js/issues/1053). So for now, I added a "keepAlive" function that requests the current block number every 55 seconds. 

