### PR TITLE
Use TBD if strategy contract fails to return name

### DIFF
--- a/src/ethereum/EthHelpers.js
+++ b/src/ethereum/EthHelpers.js
@@ -550,8 +550,14 @@ async function StratInfo(vault, strat, provider, currentTime, totalAssets, gov){
 	}
 	
 
-    
-	let name = await s.name();
+	let name = 'TBD';
+	try {
+		name = await s.name();
+	} catch(e) {
+		console.warn('Calling strategy.name() failed');
+		console.warn(e);
+	}
+
 	if(name.includes('StrategyLenderYieldOptimiser')){
 
 


### PR DESCRIPTION
There's a strategy at [0x016919386387898E4Fa87c7c4D3324F75f178F12](https://etherscan.io/address/0x016919386387898E4Fa87c7c4D3324F75f178F12) currently used in the USDT 0.4.3 vault on Ethereum that reverts when its `name` function is called. Looking at the strategy's code I see:
```
function name() external view override returns (string memory) {
    return string(abi.encodePacked("StrategyIdleV2 ", IIdleTokenV4(idleYieldToken).name()));
}
```
That is, the strategy's name depends on the name of the strategy's `idleYieldToken`. Checking etherscan I see:

![image](https://user-images.githubusercontent.com/89237203/182290727-cd899323-6e4e-47ed-b371-2b6bd7a55426.png)

Note that idleYieldToken is set to the zero address which causes `IdleTokenV4(idleYieldToken).name()` to revert. 

Side note.. instead of showing an error for name, it looks like etherscan shows the function's documentation from BaseStrategy.sol:
```
/**
 * @notice This Strategy's name.
 * @dev
 *  You can use this field to manage the "version" of this Strategy, e.g.
 *  `StrategySomethingOrOtherV1`. However, "API Version" is managed by
 *  `apiVersion()` function above.
 * @return This Strategy's name.
 */
function name() external view virtual returns (string memory);
```

I looked around yearn's github for guidance on how to handle this and reproduced what I found here in the subgraph:
https://github.com/yearn/yearn-vaults-v2-subgraph/blob/main/src/utils/strategy/strategy.ts#L54
