### PR TITLE
Support https rpc gateways

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -11,8 +11,7 @@ export default {
 			'name': 'ethereum',
 			'explorer': 'https://etherscan.io',
 			'providers': [
-				'wss://erigon:iAlBsaOWZtIrYNMR4a4J@node.yearn.network',
-				'wss://erigon:FcqDXWV3TEwS2-r3@erigon.yearn.vision'
+				'https://rpc.ankr.com/eth'
 			]
 		},
 		{
@@ -20,7 +19,7 @@ export default {
 			'name': 'fantom',
 			'explorer': 'https://ftmscan.com',
 			'providers': [
-				'wss://opera:zgNmpZno8CFXCVvHm7I2JZ6NETmEotAA@fantom.yearn.science'
+				'https://rpc.ankr.com/fantom'
 			]
 		}
 	]


### PR DESCRIPTION
Our current websocket rpcs recently started hanging on connection with status 101 (switching protocols):
wss://erigon:iAlBsaOWZtIrYNMR4a4J@node.yearn.network
wss://erigon:FcqDXWV3TEwS2-r3@erigon.yearn.vision
wss://opera:zgNmpZno8CFXCVvHm7I2JZ6NETmEotAA@fantom.yearn.science
![image](https://user-images.githubusercontent.com/89237203/187317141-fa34066c-6c9f-44ff-8a1f-590c7dee2b48.png)

While that gets sorted out, I added support for https rpcs and temporarily configured the app to use endpoints from ankr:
https://rpc.ankr.com/eth
https://rpc.ankr.com/fantom

