### PR TITLE
fix: add safety checks

### DIFF
--- a/src/components/Vault/SimulatorProvider.js
+++ b/src/components/Vault/SimulatorProvider.js
@@ -30,11 +30,9 @@ export default function SimulatorProvider({children}) {
 	}, [vault]);
 
 	const degradationTime = useMemo(() => {
-		if(vault && vault.lockedProfitDegradation) {
-			if(vault.lockedProfitDegradation?.eq(0)) return 0;
-			const degradationCoefficient = BigNumber.from('1000000000000000000');
-			return degradationCoefficient.div(vault.lockedProfitDegradation);
-		}
+		if((vault?.lockedProfitDegradation || ethers.constants.Zero).eq(0)) return 0;
+		const degradationCoefficient = BigNumber.from('1000000000000000000');
+		return degradationCoefficient.div(vault.lockedProfitDegradation);
 	}, [vault]);
 
 	const jumpToTotalProfitUnlock = useCallback(async (provider) => {

--- a/src/components/Vault/Strategy.js
+++ b/src/components/Vault/Strategy.js
@@ -40,7 +40,11 @@ export default function Strategy({strategy}) {
 	const simulator = useSimulator();
 	const strategyHarvestHistory = reports.filter(r => r.strategy_address === strategy.address);
 	const [showHarvestHistory, setShowHarvestHistory] = useState(false);
-	const lastStrategy = useMemo(() => strategy.address === vault.withdrawalQueue.at(-1).address, [strategy, vault]);
+
+	const lastStrategy = useMemo(() => {
+		const last = (vault?.withdrawalQueue || [])?.at(-1)?.address || '';
+		return strategy.address === last;
+	}, [strategy, vault]);
 
 	function latestHarvest(strategy) {
 		return new Date(strategy.lastReport * 1000);

--- a/src/components/Vault/Summary.js
+++ b/src/components/Vault/Summary.js
@@ -2,7 +2,7 @@ import React, {useEffect, useState, useMemo} from 'react';
 import dayjs from 'dayjs';
 import duration from '../../../node_modules/dayjs/plugin/duration';
 import {TiWarning} from 'react-icons/ti';
-import {FixedNumber} from 'ethers';
+import {ethers, FixedNumber} from 'ethers';
 import {formatTokens, formatPercent, formatBps} from '../../utils/utils';
 import {useSimulator} from './SimulatorProvider';
 import {useVault} from './VaultProvider';
@@ -72,12 +72,12 @@ export default function Summary({className}) {
 	}, [vault, simulator, liveApy]);
 
 	const allocated = useMemo(() => {
-		if(vault.totalAssets.eq(0)) return 0;
+		if((vault?.totalAssets || ethers.constants.Zero).eq(0)) return 0;
 		return vault.debtRatio / 10_000;
 	}, [vault]);
 
 	const utilization = useMemo(() => {
-		if(vault.depositLimit.eq(0)) return NaN;
+		if((vault?.depositLimit || ethers.constants.Zero).eq(0)) return NaN;
 		return 1 - vault.availableDepositLimit?.mul(10_000).div(vault.depositLimit) / 10_000;
 	}, [vault]);
 


### PR DESCRIPTION
Add some safety checks to prevent crashed on undefined.


We have this function in the web-lib that could help to avoid theses issues:
```
export const formatBN = (amount?: BigNumberish): BigNumber => {
	return BigNumber.from(amount || 0);
};
```

I also suggest to add the `?.` notation for all nested properties and to always use a fallback!